### PR TITLE
Fix accounts page connection behavior

### DIFF
--- a/frontend/src/pages/accounts/hooks/useAccounts.ts
+++ b/frontend/src/pages/accounts/hooks/useAccounts.ts
@@ -11,16 +11,16 @@ export const useAccounts = (
   const [accounts, setAccounts] = useState<Account[]>([])
   const [loading, setLoading] = useState(true)
 
-  const loadAccounts = async () => {
+  const loadAccounts = async (showLoading = false) => {
     try {
-      setLoading(true)
+      if (showLoading) setLoading(true)
       const accountsData = await apiService.fetchAccounts()
       setAccounts(accountsData)
     } catch (error) {
       console.error('Error loading accounts:', error)
       onError('Failed to load accounts')
     } finally {
-      setLoading(false)
+      if (showLoading) setLoading(false)
     }
   }
 
@@ -50,6 +50,7 @@ export const useAccounts = (
   const handleDeleteAccount = async (accountId: string) => {
     try {
       console.log('Disconnecting account:', accountId)
+      await apiService.deleteAccount(accountId)
       onSuccess('Account disconnected successfully')
       await loadAccounts()
     } catch (error) {
@@ -68,7 +69,7 @@ export const useAccounts = (
   }
 
   useEffect(() => {
-    loadAccounts()
+    loadAccounts(true)
   }, [])
 
   return {

--- a/frontend/src/services/api/account-service.ts
+++ b/frontend/src/services/api/account-service.ts
@@ -20,6 +20,10 @@ export class AccountService {
   async toggleAccountVisibility(accountId: string, isVisible: boolean): Promise<{ success: boolean }> {
     return httpClient.put(`/api/accounts/${accountId}/visibility`, { isVisible })
   }
+
+  async deleteAccount(accountId: string): Promise<{ success: boolean }> {
+    return httpClient.delete(`/api/accounts/${accountId}`)
+  }
 }
 
 export const accountService = new AccountService()

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -152,6 +152,10 @@ class ApiService {
     return accountService.toggleAccountVisibility(accountId, isVisible)
   }
 
+  async deleteAccount(accountId: string) {
+    return accountService.deleteAccount(accountId)
+  }
+
   // Investment methods
   async fetchInvestments() {
     return investmentService.fetchInvestments()

--- a/src/routes/accounts.ts
+++ b/src/routes/accounts.ts
@@ -150,4 +150,36 @@ router.put('/:accountId/visibility', async (req, res) => {
   }
 });
 
+/**
+ * @swagger
+ * /api/accounts/{accountId}:
+ *   delete:
+ *     summary: Delete an account
+ *     description: Remove a single account and its transactions
+ *     tags: [Accounts]
+ *     parameters:
+ *       - in: path
+ *         name: accountId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The account ID to delete
+ *     responses:
+ *       200:
+ *         description: Account deleted successfully
+ */
+router.delete('/:accountId', async (req, res) => {
+  try {
+    const { accountId } = req.params;
+
+    await database.run('DELETE FROM transactions WHERE account_id = ?', [accountId]);
+    await database.run('DELETE FROM accounts WHERE account_id = ?', [accountId]);
+
+    res.json({ success: true, message: 'Account deleted successfully' });
+  } catch (error) {
+    logger.error('Error deleting account:', error);
+    res.status(500).json({ error: 'Failed to delete account' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- avoid loading spinner when refreshing accounts after bank events
- enable deleting an account via API
- use new API endpoint from frontend

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: cannot fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68770e26839083208796c5639587f2e6