### PR TITLE
Use unified logger across backend

### DIFF
--- a/src/controllers/dashboard/analytics.controller.ts
+++ b/src/controllers/dashboard/analytics.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { database } from '../../database';
+import { logger } from '../../utils/logger';
 
 /**
  * @swagger
@@ -115,7 +116,7 @@ export const getFinancialHealth = async (_req: Request, res: Response) => {
       score
     });
   } catch (error) {
-    console.error('Error fetching financial health:', error);
+    logger.error('Error fetching financial health:', error);
     res.status(500).json({ error: 'Failed to fetch financial health data' });
   }
 };
@@ -231,7 +232,7 @@ export const getCashFlowAnalysis = async (req: Request, res: Response) => {
       trend
     });
   } catch (error) {
-    console.error('Error fetching cash flow analysis:', error);
+    logger.error('Error fetching cash flow analysis:', error);
     res.status(500).json({ error: 'Failed to fetch cash flow analysis' });
   }
 };
@@ -342,7 +343,7 @@ export const getSpendingTrends = async (req: Request, res: Response) => {
       percentageChange
     });
   } catch (error) {
-    console.error('Error fetching spending trends:', error);
+    logger.error('Error fetching spending trends:', error);
     res.status(500).json({ error: 'Failed to fetch spending trends' });
   }
 };

--- a/src/controllers/dashboard/overview.controller.ts
+++ b/src/controllers/dashboard/overview.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { database } from '../../database';
+import { logger } from '../../utils/logger';
 
 /**
  * @swagger
@@ -70,7 +71,7 @@ export const getOverview = async (_req: Request, res: Response) => {
       todayNetFlow
     });
   } catch (error) {
-    console.error('Error fetching overview:', error);
+    logger.error('Error fetching overview:', error);
     res.status(500).json({ error: 'Failed to fetch overview data' });
   }
 };
@@ -151,7 +152,7 @@ export const getEarnings = async (_req: Request, res: Response) => {
       sevenDayAverage
     });
   } catch (error) {
-    console.error('Error fetching earnings:', error);
+    logger.error('Error fetching earnings:', error);
     res.status(500).json({ error: 'Failed to fetch earnings data' });
   }
 };

--- a/src/controllers/dashboard/spending.controller.ts
+++ b/src/controllers/dashboard/spending.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { database } from '../../database';
+import { logger } from '../../utils/logger';
 
 /**
  * @swagger
@@ -83,7 +84,7 @@ export const getSpendingData = async (req: Request, res: Response) => {
       totalSpending
     });
   } catch (error) {
-    console.error('Error fetching spending data:', error);
+    logger.error('Error fetching spending data:', error);
     res.status(500).json({ error: 'Failed to fetch spending data' });
   }
 };
@@ -167,7 +168,7 @@ export const getSpendingByCategory = async (req: Request, res: Response) => {
       totalSpending
     });
   } catch (error) {
-    console.error('Error fetching spending by category:', error);
+    logger.error('Error fetching spending by category:', error);
     res.status(500).json({ error: 'Failed to fetch spending by category' });
   }
 };
@@ -246,7 +247,7 @@ export const getMonthlySpendingComparison = async (_req: Request, res: Response)
       percentageChange
     });
   } catch (error) {
-    console.error('Error fetching monthly spending comparison:', error);
+    logger.error('Error fetching monthly spending comparison:', error);
     res.status(500).json({ error: 'Failed to fetch monthly spending comparison' });
   }
 };
@@ -331,7 +332,7 @@ export const getTopMerchants = async (req: Request, res: Response) => {
       }))
     });
   } catch (error) {
-    console.error('Error fetching top merchants:', error);
+    logger.error('Error fetching top merchants:', error);
     res.status(500).json({ error: 'Failed to fetch top merchants' });
   }
 };

--- a/src/controllers/transactions/analytics.controller.ts
+++ b/src/controllers/transactions/analytics.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { bankService } from '../../services/bank.service';
 import { database } from '../../database';
+import { logger } from '../../utils/logger';
 
 /**
  * @swagger
@@ -92,7 +93,7 @@ export const getTrends = async (req: Request, res: Response) => {
       }
     });
   } catch (error) {
-    console.error('Error getting trends:', error);
+    logger.error('Error getting trends:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -128,7 +129,7 @@ export const getInsights = async (_req: Request, res: Response) => {
     const result = await bankService.getBudgetInsights();
     res.json(result);
   } catch (error) {
-    console.error('Error getting insights:', error);
+    logger.error('Error getting insights:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -249,7 +250,7 @@ export const getCategoryAnalysis = async (req: Request, res: Response) => {
       topMerchants: topMerchants || []
     });
   } catch (error) {
-    console.error('Error getting category analysis:', error);
+    logger.error('Error getting category analysis:', error);
     return res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -356,7 +357,7 @@ export const getAlerts = async (_req: Request, res: Response) => {
       }
     });
   } catch (error) {
-    console.error('Error getting alerts:', error);
+    logger.error('Error getting alerts:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/src/controllers/transactions/banks.controller.ts
+++ b/src/controllers/transactions/banks.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { schedulerService } from '../../services/scheduler.service';
 import { database } from '../../database';
+import { logger } from '../../utils/logger';
 
 /**
  * @swagger
@@ -55,7 +56,7 @@ export const getConnectedBanks = async (_req: Request, res: Response) => {
     
     res.json({ banks: connectedBanks });
   } catch (error) {
-    console.error('Error fetching connected banks:', error);
+    logger.error('Error fetching connected banks:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -116,7 +117,7 @@ export const deleteBankConnection = async (req: Request, res: Response) => {
       throw error;
     }
   } catch (error) {
-    console.error('Error deleting bank connection:', error);
+    logger.error('Error deleting bank connection:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -185,7 +186,7 @@ export const getHealthCheck = async (_req: Request, res: Response) => {
       timestamp: new Date().toISOString()
     });
   } catch (error) {
-    console.error('Health check error:', error);
+    logger.error('Health check error:', error);
     res.status(500).json({ 
       status: 'unhealthy', 
       error: (error as Error).message,
@@ -216,7 +217,7 @@ export const syncTransactions = async (_req: Request, res: Response) => {
       timestamp: new Date().toISOString()
     });
   } catch (error) {
-    console.error('Error initiating sync:', error);
+    logger.error('Error initiating sync:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -241,7 +242,7 @@ export const getSchedulerStatus = (_req: Request, res: Response) => {
       timestamp: new Date().toISOString()
     });
   } catch (error) {
-    console.error('Error getting scheduler status:', error);
+    logger.error('Error getting scheduler status:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/src/controllers/transactions/data.controller.ts
+++ b/src/controllers/transactions/data.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { database } from '../../database';
+import { logger } from '../../utils/logger';
 
 /**
  * @swagger
@@ -44,7 +45,7 @@ export const getDateRange = async (_req: Request, res: Response) => {
       totalTransactions: result.totalTransactions
     });
   } catch (error) {
-    console.error('Error getting date range:', error);
+    logger.error('Error getting date range:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -179,7 +180,7 @@ export const getTransactions = async (req: Request, res: Response) => {
       }
     });
   } catch (error) {
-    console.error('Error getting transactions:', error);
+    logger.error('Error getting transactions:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -272,7 +273,7 @@ export const getTransactionSummary = async (req: Request, res: Response) => {
       }
     });
   } catch (error) {
-    console.error('Error getting transaction summary:', error);
+    logger.error('Error getting transaction summary:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/src/controllers/transactions/fetch.controller.ts
+++ b/src/controllers/transactions/fetch.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { bankService } from '../../services/bank.service';
 import { database } from '../../database';
+import { logger } from '../../utils/logger';
 
 /**
  * @swagger
@@ -69,7 +70,7 @@ export const fetchTransactions = async (req: Request, res: Response) => {
           });
         }
       } catch (error) {
-        console.error(`Error fetching transactions for ${institution.name}:`, error);
+        logger.error(`Error fetching transactions for ${institution.name}:`, error);
         results.push({
           institution: institution.name,
           error: (error as Error).message
@@ -84,7 +85,7 @@ export const fetchTransactions = async (req: Request, res: Response) => {
       results
     });
   } catch (error) {
-    console.error('Error fetching transactions:', error);
+    logger.error('Error fetching transactions:', error);
     res.status(500).json({ error: 'Internal server error' });
   }
 };
@@ -174,7 +175,7 @@ export const fetchHistoricalTransactions = async (req: Request, res: Response) =
           transactionCount: result.transactions.length
         });
       } catch (error) {
-        console.error(`Error fetching historical transactions for account ${account.name}:`, error);
+        logger.error(`Error fetching historical transactions for account ${account.name}:`, error);
         results.push({
           accountId: account.id,
           accountName: account.name,
@@ -192,7 +193,7 @@ export const fetchHistoricalTransactions = async (req: Request, res: Response) =
       results
     });
   } catch (error) {
-    console.error('Error fetching historical transactions:', error);
+    logger.error('Error fetching historical transactions:', error);
     return res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/src/database/connection.ts
+++ b/src/database/connection.ts
@@ -1,6 +1,7 @@
 import sqlite3 from 'sqlite3';
 import path from 'path';
 import fs from 'fs';
+import { logger } from '../utils/logger';
 
 // Enable verbose mode for better debugging
 const sqlite = sqlite3.verbose();
@@ -37,7 +38,7 @@ export class DatabaseConnection {
         throw error;
       }
     } catch (error) {
-      console.error('Database initialization failed:', error);
+      logger.error('Database initialization failed:', error);
       throw error;
     }
   }
@@ -50,7 +51,7 @@ export class DatabaseConnection {
   }
 
   private async createBasicTables(): Promise<void> {
-    console.log('Creating institutions table...');
+    logger.info('Creating institutions table...');
     await this.runDirect(`
       CREATE TABLE IF NOT EXISTS institutions (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -64,7 +65,7 @@ export class DatabaseConnection {
       )
     `);
 
-    console.log('Creating accounts table...');
+    logger.info('Creating accounts table...');
     await this.runDirect(`
       CREATE TABLE IF NOT EXISTS accounts (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -83,7 +84,7 @@ export class DatabaseConnection {
       )
     `);
 
-    console.log('Creating transactions table...');
+    logger.info('Creating transactions table...');
     await this.runDirect(`
       CREATE TABLE IF NOT EXISTS transactions (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -104,7 +105,7 @@ export class DatabaseConnection {
       )
     `);
 
-    console.log('Creating budgets table...');
+    logger.info('Creating budgets table...');
     await this.runDirect(`
       CREATE TABLE IF NOT EXISTS budgets (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -120,7 +121,7 @@ export class DatabaseConnection {
   }
 
   private async createInvestmentTables(): Promise<void> {
-    console.log('Creating securities table...');
+    logger.info('Creating securities table...');
     await this.runDirect(`
       CREATE TABLE IF NOT EXISTS securities (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -138,7 +139,7 @@ export class DatabaseConnection {
       )
     `);
 
-    console.log('Creating holdings table...');
+    logger.info('Creating holdings table...');
     await this.runDirect(`
       CREATE TABLE IF NOT EXISTS holdings (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -157,7 +158,7 @@ export class DatabaseConnection {
       )
     `);
 
-    console.log('Creating investment_transactions table...');
+    logger.info('Creating investment_transactions table...');
     await this.runDirect(`
       CREATE TABLE IF NOT EXISTS investment_transactions (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -180,7 +181,7 @@ export class DatabaseConnection {
       )
     `);
 
-    console.log('Creating market_data table...');
+    logger.info('Creating market_data table...');
     await this.runDirect(`
       CREATE TABLE IF NOT EXISTS market_data (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -249,7 +250,7 @@ export class DatabaseConnection {
     await this.ensureInitialized();
     
     try {
-      console.log('Cleaning all data from database...');
+      logger.info('Cleaning all data from database...');
       
       // Delete in reverse order of dependencies to avoid foreign key constraints
       await this.run('DELETE FROM market_data');
@@ -264,9 +265,9 @@ export class DatabaseConnection {
       // Reset auto-increment counters
       await this.run("UPDATE sqlite_sequence SET seq = 0 WHERE name IN ('institutions', 'accounts', 'transactions', 'budgets', 'securities', 'holdings', 'investment_transactions', 'market_data')");
       
-      console.log('Database cleaned successfully - all data removed');
+      logger.info('Database cleaned successfully - all data removed');
     } catch (error) {
-      console.error('Error cleaning database:', error);
+      logger.error('Error cleaning database:', error);
       throw error;
     }
   }

--- a/src/routes/link-token.ts
+++ b/src/routes/link-token.ts
@@ -90,7 +90,7 @@ router.post('/link/token/create', async (req, res) => {
       expiration: response.data.expiration 
     });
   } catch (err: any) {
-    console.error('createLinkToken error:', {
+    logger.error('createLinkToken error:', {
       error: err.message,
       status: err.response?.status,
       data: err.response?.data,

--- a/src/routes/sandbox.ts
+++ b/src/routes/sandbox.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { plaidClient } from '../plaidClient';
 import { database } from '../database';
+import { logger } from '../utils/logger';
 
 const router = Router();
 
@@ -63,7 +64,7 @@ router.post('/sandbox/public_token/create', async (req, res) => {
     });
     res.json({ public_token: data.public_token });
   } catch (err) {
-    console.error('sandboxPublicTokenCreate error:', err);
+    logger.error('sandboxPublicTokenCreate error:', err);
     res.status(500).json({ error: 'Sandbox public_token failed' });
   }
 });
@@ -98,7 +99,7 @@ router.post('/database/clean', async (_req, res) => {
     await database.cleanAllData();
     res.json({ message: 'Database cleaned successfully - all data removed' });
   } catch (err) {
-    console.error('Database cleanup error:', err);
+    logger.error('Database cleanup error:', err);
     res.status(500).json({ error: 'Failed to clean database' });
   }
 });

--- a/src/routes/sync.ts
+++ b/src/routes/sync.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import { database } from '../database';
+import { logger } from '../utils/logger';
 
 const router = express.Router();
 
@@ -62,7 +63,7 @@ router.get('/status', async (_req, res) => {
       nextAutoSync
     });
   } catch (error) {
-    console.error('Error getting sync status:', error);
+    logger.error('Error getting sync status:', error);
     res.status(500).json({ error: 'Failed to get sync status' });
   }
 });
@@ -102,7 +103,7 @@ router.post('/accounts', async (_req, res) => {
       message: 'Account sync completed successfully'
     });
   } catch (error) {
-    console.error('Error syncing accounts:', error);
+    logger.error('Error syncing accounts:', error);
     res.status(500).json({ 
       success: false,
       error: 'Failed to sync accounts' 
@@ -141,7 +142,7 @@ router.post('/balances', async (_req, res) => {
       message: 'Account balances synced successfully'
     });
   } catch (error) {
-    console.error('Error syncing account balances:', error);
+    logger.error('Error syncing account balances:', error);
     res.status(500).json({ error: 'Failed to sync account balances' });
   }
 });

--- a/src/services/bank/analytics.service.ts
+++ b/src/services/bank/analytics.service.ts
@@ -1,5 +1,6 @@
 import { database, Database } from '../../database';
 import { subDays, formatISO } from 'date-fns';
+import { logger } from '../../utils/logger';
 
 export class AnalyticsService {
   private database: Database;
@@ -15,7 +16,8 @@ export class AnalyticsService {
     savingsOpportunities: { category: string; potentialSavings: number; suggestion: string }[];
   }> {
     try {
-      console.log('📊 Analyzing budget insights...');
+      // Use centralized logger instead of console.log for consistency
+      logger.info('📊 Analyzing budget insights...');
 
       const last30Days = formatISO(subDays(new Date(), 30), { representation: 'date' });
       const last90Days = formatISO(subDays(new Date(), 90), { representation: 'date' });
@@ -52,7 +54,7 @@ export class AnalyticsService {
         savingsOpportunities
       };
     } catch (error) {
-      console.error('Error analyzing budget insights:', error);
+      logger.error('Error analyzing budget insights:', error);
       throw error;
     }
   }
@@ -191,7 +193,7 @@ export class AnalyticsService {
     };
   }> {
     try {
-      console.log(`📊 Generating advanced transaction summary for ${period}...`);
+      logger.info(`📊 Generating advanced transaction summary for ${period}...`);
 
       // Calculate date ranges based on period
       const { startDate, endDate, prevStartDate, prevEndDate } = this.calculatePeriodDates(period);
@@ -223,7 +225,7 @@ export class AnalyticsService {
         comparison
       };
     } catch (error) {
-      console.error('Error generating advanced transaction summary:', error);
+      logger.error('Error generating advanced transaction summary:', error);
       throw error;
     }
   }
@@ -387,7 +389,7 @@ export class AnalyticsService {
         avgDailySpending
       };
     } catch (error) {
-      console.error('Error getting spending trends:', error);
+      logger.error('Error getting spending trends:', error);
       throw error;
     }
   }

--- a/src/services/bank/connection.service.ts
+++ b/src/services/bank/connection.service.ts
@@ -1,5 +1,6 @@
 import { database, Database } from '../../database';
 import { plaidClient } from '../../plaidClient';
+import { logger } from '../../utils/logger';
 
 export class BankConnectionService {
   private database: Database;
@@ -42,7 +43,7 @@ export class BankConnectionService {
         item_id: tokenData.item_id
       };
     } catch (error) {
-      console.error('Error adding bank connection:', error);
+      logger.error('Error adding bank connection:', error);
       throw error;
     }
   }
@@ -67,7 +68,7 @@ export class BankConnectionService {
         });
       }
     } catch (error) {
-      console.error('Error fetching accounts:', error);
+      logger.error('Error fetching accounts:', error);
       throw error;
     }
   }
@@ -77,7 +78,7 @@ export class BankConnectionService {
     try {
       return await this.database.getInstitutions();
     } catch (error) {
-      console.error('Error fetching connected banks:', error);
+      logger.error('Error fetching connected banks:', error);
       throw error;
     }
   }
@@ -85,7 +86,7 @@ export class BankConnectionService {
   // Remove a bank connection
   async removeBankConnection(institutionId: number): Promise<void> {
     try {
-      console.log(`🗑️  Removing bank connection for institution ${institutionId}...`);
+      logger.info(`🗑️  Removing bank connection for institution ${institutionId}...`);
 
       // Get institution to validate it exists
       const institution = await this.database.institutions.getInstitutionById(institutionId);
@@ -98,9 +99,9 @@ export class BankConnectionService {
         await plaidClient.itemRemove({
           access_token: institution.access_token
         });
-        console.log(`✅ Successfully removed item from Plaid`);
+        logger.info(`✅ Successfully removed item from Plaid`);
       } catch (plaidError) {
-        console.error('Error removing item from Plaid:', plaidError);
+        logger.error('Error removing item from Plaid:', plaidError);
         // Continue with database cleanup even if Plaid removal fails
       }
 
@@ -110,9 +111,9 @@ export class BankConnectionService {
       await this.database.investment.deleteInvestmentDataByInstitution(institutionId);
       await this.database.institutions.deleteInstitution(institutionId);
 
-      console.log(`✅ Successfully removed bank connection and all associated data`);
+      logger.info(`✅ Successfully removed bank connection and all associated data`);
     } catch (error) {
-      console.error('Error removing bank connection:', error);
+      logger.error('Error removing bank connection:', error);
       throw error;
     }
   }
@@ -142,7 +143,7 @@ export class BankConnectionService {
 
       await this.fetchAndSaveAccounts(institution.access_token);
     } catch (error) {
-      console.error('Error refreshing accounts:', error);
+      logger.error('Error refreshing accounts:', error);
       throw error;
     }
   }
@@ -152,7 +153,7 @@ export class BankConnectionService {
     try {
       return await this.database.accounts.getAccountsByInstitution(institutionId);
     } catch (error) {
-      console.error('Error fetching accounts for institution:', error);
+      logger.error('Error fetching accounts for institution:', error);
       throw error;
     }
   }
@@ -160,22 +161,22 @@ export class BankConnectionService {
   // Sync account balances for all connected institutions
   async syncAccountBalances(): Promise<void> {
     try {
-      console.log('🔄 Syncing account balances...');
+      logger.info('🔄 Syncing account balances...');
       
       const institutions = await this.database.getInstitutions();
       
       for (const institution of institutions) {
         try {
           await this.syncAccountBalancesForInstitution(institution.access_token, institution.id);
-          console.log(`✅ Synced balances for institution ${institution.id}`);
+          logger.debug(`✅ Synced balances for institution ${institution.id}`);
         } catch (error) {
-          console.error(`❌ Failed to sync balances for institution ${institution.id}:`, error);
+          logger.error(`❌ Failed to sync balances for institution ${institution.id}:`, error);
         }
       }
       
-      console.log('✅ Account balance sync completed');
+      logger.info('✅ Account balance sync completed');
     } catch (error) {
-      console.error('Error syncing account balances:', error);
+      logger.error('Error syncing account balances:', error);
       throw error;
     }
   }
@@ -206,7 +207,7 @@ export class BankConnectionService {
       `, [institution_id]);
       
     } catch (error) {
-      console.error('Error syncing account balances for institution:', error);
+      logger.error('Error syncing account balances for institution:', error);
       throw error;
     }
   }

--- a/src/services/bank/transaction.service.ts
+++ b/src/services/bank/transaction.service.ts
@@ -1,6 +1,7 @@
 import { database, Database } from '../../database';
 import { plaidClient } from '../../plaidClient';
 import { subDays, formatISO } from 'date-fns';
+import { logger } from '../../utils/logger';
 
 export class TransactionService {
   private database: Database;
@@ -19,7 +20,7 @@ export class TransactionService {
       
       // If no institutions are connected, return empty results
       if (institutions.length === 0) {
-        console.log('📭 No banks connected. Returning empty transaction data.');
+        logger.info('📭 No banks connected. Returning empty transaction data.');
         return {
           transactions: [],
           summary: {
@@ -43,7 +44,7 @@ export class TransactionService {
           );
           allTransactions.push(...transactions);
         } catch (error) {
-          console.error(`Error fetching transactions for institution ${institution.id}:`, error);
+          logger.error(`Error fetching transactions for institution ${institution.id}:`, error);
           // Continue with other institutions
         }
       }
@@ -56,7 +57,7 @@ export class TransactionService {
         summary
       };
     } catch (error) {
-      console.error('Error fetching all transactions:', error);
+      logger.error('Error fetching all transactions:', error);
       throw error;
     }
   }
@@ -68,7 +69,7 @@ export class TransactionService {
     days: number
   ): Promise<any[]> {
     try {
-      console.log(`🔄 Fetching transactions for institution ${institution_id} for ${days} days...`);
+      logger.info(`🔄 Fetching transactions for institution ${institution_id} for ${days} days...`);
 
       const allTransactions: any[] = [];
       let cursor: string | null = null;
@@ -120,7 +121,7 @@ export class TransactionService {
 
             allTransactions.push(tx);
           } catch (error) {
-            console.error(`Error saving transaction ${tx.transaction_id}:`, error);
+            logger.error(`Error saving transaction ${tx.transaction_id}:`, error);
             // Continue processing other transactions
           }
         }
@@ -153,7 +154,7 @@ export class TransactionService {
               pending: tx.pending || false
             });
           } catch (error) {
-            console.error(`Error updating transaction ${tx.transaction_id}:`, error);
+            logger.error(`Error updating transaction ${tx.transaction_id}:`, error);
             // Continue processing other transactions
           }
         }
@@ -163,7 +164,7 @@ export class TransactionService {
           try {
             await this.database.deleteTransaction(removedTx.transaction_id);
           } catch (error) {
-            console.error(`Error removing transaction ${removedTx.transaction_id}:`, error);
+            logger.error(`Error removing transaction ${removedTx.transaction_id}:`, error);
             // Continue processing other transactions
           }
         }
@@ -171,10 +172,10 @@ export class TransactionService {
         cursor = next_cursor;
         hasMore = has_more;
 
-        console.log(`📥 Processed ${added.length} added, ${modified.length} modified, ${removed.length} removed transactions. Has more: ${hasMore}`);
+        logger.debug(`📥 Processed ${added.length} added, ${modified.length} modified, ${removed.length} removed transactions. Has more: ${hasMore}`);
       }
 
-      console.log(`✅ Total transactions processed: ${allTransactions.length}`);
+      logger.info(`✅ Total transactions processed: ${allTransactions.length}`);
 
       // Return transactions from database within the requested date range
       const endDate = formatISO(new Date(), { representation: 'date' });
@@ -186,7 +187,7 @@ export class TransactionService {
         end_date: endDate
       });
     } catch (error) {
-      console.error(`Error fetching transactions for institution ${institution_id}:`, error);
+      logger.error(`Error fetching transactions for institution ${institution_id}:`, error);
       throw error;
     }
   }
@@ -237,7 +238,7 @@ export class TransactionService {
     };
   }> {
     try {
-      console.log(`🔍 Filtering transactions with criteria:`, filters);
+      logger.debug(`🔍 Filtering transactions with criteria:`, filters);
 
       const endDate = formatISO(new Date(), { representation: 'date' });
       const startDate = formatISO(subDays(new Date(), filters.days || 30), { representation: 'date' });
@@ -296,7 +297,7 @@ export class TransactionService {
         summary
       };
     } catch (error) {
-      console.error('Error filtering transactions:', error);
+      logger.error('Error filtering transactions:', error);
       throw error;
     }
   }
@@ -344,7 +345,7 @@ export class TransactionService {
     try {
       return await this.database.transactions.getTransactionsByDateRange(startDate, endDate);
     } catch (error) {
-      console.error('Error getting transactions by date range:', error);
+      logger.error('Error getting transactions by date range:', error);
       throw error;
     }
   }
@@ -354,7 +355,7 @@ export class TransactionService {
     try {
       return await this.database.transactions.getTodaysTransactions();
     } catch (error) {
-      console.error('Error getting today\'s transactions:', error);
+      logger.error('Error getting today\'s transactions:', error);
       throw error;
     }
   }


### PR DESCRIPTION
## Summary
- replace `console` statements with centralized logger
- clean up database connection logs
- unify logging for routes and services

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68784eeca69c83209c0062bdc70f6613