### PR TITLE
Fix bank connection sync issue

### DIFF
--- a/frontend/src/components/bank-management/hooks/useBankManagement.ts
+++ b/frontend/src/components/bank-management/hooks/useBankManagement.ts
@@ -91,18 +91,26 @@ export const useBankManagement = () => {
       console.log('Token exchange completed, reloading banks...')
       
       await loadBanks()
-      
+
+      // Sync transactions for the newly connected bank
+      try {
+        await syncData()
+        dispatchAppEvent(APP_EVENTS.DATA_SYNC_COMPLETED)
+      } catch (syncError) {
+        console.error('Post-connect sync failed:', syncError)
+      }
+
       // Dispatch global event to notify other components
       dispatchAppEvent(APP_EVENTS.BANK_CONNECTION_CHANGED, {
         institution: metadata.institution
       })
-      
+
       showSuccess('Bank connected successfully')
     } catch (error: any) {
       console.error('Bank connection error:', error)
       showError(error.message || 'Failed to connect bank')
     }
-  }, [connectBank, initializePlaid, exchangeToken, loadBanks, showError, showSuccess, clearNotifications])
+  }, [connectBank, initializePlaid, exchangeToken, loadBanks, syncData, showError, showSuccess, clearNotifications])
 
   // Disconnect bank operation
   const handleDisconnectBank = useCallback(async (institutionId: string) => {

--- a/frontend/src/components/bank-management/hooks/useBankOperations.ts
+++ b/frontend/src/components/bank-management/hooks/useBankOperations.ts
@@ -8,7 +8,7 @@ export const useBankOperations = () => {
   const syncData = useCallback(async () => {
     setSyncing(true)
     try {
-      const response = await fetch('/api/sync/manual', { method: 'POST' })
+      const response = await fetch('/api/transactions/sync', { method: 'POST' })
       const data = await response.json()
       
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- update bank operations hook to call new API route `/api/transactions/sync`
- trigger transaction sync and notify app after successfully connecting a bank

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68785ef7fc6c8320aa45f7180d333e60