### PR TITLE
Fix transactions pagination info

### DIFF
--- a/frontend/src/pages/transactions/hooks/useTransactionData.ts
+++ b/frontend/src/pages/transactions/hooks/useTransactionData.ts
@@ -58,7 +58,7 @@ export const useTransactionData = (
         filters.amountRange.max < 10000 ? filters.amountRange.max : undefined,
         sorting.field,
         sorting.direction,
-        1000, // Default to 1000 for open source usage
+        20,
         endDate
       )
       

--- a/frontend/src/services/apiService.ts
+++ b/frontend/src/services/apiService.ts
@@ -107,7 +107,11 @@ class ApiService {
     
     const response = await fetch(`/api/transactions?${params}`)
     if (!response.ok) throw new Error('Failed to fetch transactions')
-    return await response.json()
+    const data = await response.json()
+    return {
+      transactions: data.transactions,
+      total: data.pagination?.total ?? 0
+    }
   }
 
   async fetchTransactionsSimple(


### PR DESCRIPTION
## Summary
- return total count in `apiService.fetchTransactions`
- request 20 items per page for transaction data

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687862fa8ce08320b81159d12db963d9