### PR TITLE
Fix table scroll and analytics data

### DIFF
--- a/frontend/src/components/data-table/TransactionsDataTable.tsx
+++ b/frontend/src/components/data-table/TransactionsDataTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef, useEffect } from 'react'
 import { TransactionsDataTableProps, SortField } from './types'
 import { useTableSort, useTableSelection } from './hooks'
 import { calculatePaginationInfo } from './utils'
@@ -20,6 +20,7 @@ const TransactionsDataTable: React.FC<TransactionsDataTableProps> = ({
   onSort,
   onExport
 }) => {
+  const containerRef = useRef<HTMLDivElement>(null)
   const { sortField, sortDirection, handleSort } = useTableSort('date', 'desc', onSort)
   const { 
     selectedTransactions, 
@@ -38,8 +39,12 @@ const TransactionsDataTable: React.FC<TransactionsDataTableProps> = ({
     { key: 'category' as SortField, label: 'Category', sortable: true }
   ]
 
+  useEffect(() => {
+    containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [currentPage, sortField, sortDirection])
+
   return (
-    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm overflow-hidden">
+    <div ref={containerRef} className="bg-white dark:bg-gray-800 rounded-lg shadow-sm overflow-hidden">
       <TableHeader 
         selectedCount={selectedTransactions.size}
         onExport={onExport}

--- a/frontend/src/pages/transactions/hooks/useTransactionAnalytics.ts
+++ b/frontend/src/pages/transactions/hooks/useTransactionAnalytics.ts
@@ -1,20 +1,50 @@
-import { useMemo } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import { calculateAnalyticsData } from '../utils'
 import { generateTransactionInsights } from '../../../components/widgets/InsightsWidget'
 import { TransactionFilters, UseTransactionAnalyticsReturn } from '../types'
+import { apiService } from '../../../services/apiService'
 
 export const useTransactionAnalytics = (
   transactions: any[],
   previousPeriodTransactions: any[],
   filters: TransactionFilters
 ): UseTransactionAnalyticsReturn => {
+  const [allTransactions, setAllTransactions] = useState<any[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const resp = await apiService.fetchTransactions(
+          filters.dateRange !== 'custom' ? filters.dateRange : undefined,
+          filters.categories.length > 0 ? filters.categories : undefined,
+          filters.searchTerm || undefined,
+          1,
+          filters.customDateRange.start,
+          filters.accounts.length > 0 ? filters.accounts : undefined,
+          filters.amountRange.min > 0 ? filters.amountRange.min : undefined,
+          filters.amountRange.max < 10000 ? filters.amountRange.max : undefined,
+          'date',
+          'desc',
+          1000,
+          filters.customDateRange.end
+        )
+        setAllTransactions(resp.transactions)
+      } catch {
+        setAllTransactions(transactions)
+      }
+    }
+    load()
+  }, [filters, transactions])
+
+  const source = allTransactions.length > 0 ? allTransactions : transactions
+
   const analyticsData = useMemo(() => {
-    return calculateAnalyticsData(transactions, filters)
-  }, [transactions, filters])
+    return calculateAnalyticsData(source, filters)
+  }, [source, filters])
 
   const insights = useMemo(() => {
-    return generateTransactionInsights(transactions, previousPeriodTransactions)
-  }, [transactions, previousPeriodTransactions])
+    return generateTransactionInsights(source, previousPeriodTransactions)
+  }, [source, previousPeriodTransactions])
 
   return {
     analyticsData,


### PR DESCRIPTION
## Summary
- keep transactions table in view when sorting or paging
- compute analytics using all transactions for the current date range

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878649243f883208168dc74d397e469